### PR TITLE
Replace go.mod tool directives with install script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,4 +56,4 @@ The tick loop in `script.run()` advances by 1 second per iteration: applies any 
 - Table-driven tests with `testify/assert`
 - Docker: Alpine-based, non-root (UID 2000), port 8080
 - CI publishes to `public.ecr.aws/cardinalhq.io/flutter`
-- Go tools (`license-eye`, `golangci-lint`, `goreleaser`) are managed via `//tool` directives in `go.mod`
+- Dev tools (`golangci-lint`, `license-eye`) are installed to `./bin/` via `scripts/install-dev-tools.sh`, triggered lazily by Makefile prerequisites

--- a/Makefile
+++ b/Makefile
@@ -53,11 +53,14 @@ generate: ${all_deps}
 #
 check: test license-check lint
 
-license-check:
-	go tool license-eye header check
+license-check: bin/license-eye
+	./bin/license-eye header check
 
-lint:
-	go tool golangci-lint run --timeout 15m --config .golangci.yaml
+lint: bin/golangci-lint
+	./bin/golangci-lint run --timeout 15m --config .golangci.yaml
+
+bin/golangci-lint bin/license-eye:
+	./scripts/install-dev-tools.sh
 
 #
 # Build locally, mostly for development speed.

--- a/go.mod
+++ b/go.mod
@@ -35,9 +35,3 @@ require (
 	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
-
-//tool github.com/apache/skywalking-eyes/cmd/license-eye
-
-//tool github.com/golangci/golangci-lint/cmd/golangci-lint
-
-//tool github.com/goreleaser/goreleaser/v2

--- a/pkg/timeline/timeline.go
+++ b/pkg/timeline/timeline.go
@@ -37,7 +37,7 @@ type Metric struct {
 	Frequency          config.Duration `json:"frequency,omitempty"` // optional, defaults to DefaultFrequency (10s)
 	ResourceAttributes map[string]any  `json:"resourceAttributes"`
 	Variants           []Variant       `json:"variants"`
-	Description         string         `json:"description"`
+	Description        string          `json:"description"`
 }
 
 type NoiseConfig struct {
@@ -61,11 +61,11 @@ type Segment struct {
 }
 
 type Trace struct {
-	Ref      string             `json:"ref"`
-	Name     string             `json:"name"`
-	Exemplar traceproducer.Span `json:"exemplar"`
-	Variants []TraceVariant     `json:"variants"`
-	Description         string         `json:"description"`
+	Ref         string             `json:"ref"`
+	Name        string             `json:"name"`
+	Exemplar    traceproducer.Span `json:"exemplar"`
+	Variants    []TraceVariant     `json:"variants"`
+	Description string             `json:"description"`
 }
 
 type TraceVariant struct {

--- a/pkg/traceproducer/traceproducer_test.go
+++ b/pkg/traceproducer/traceproducer_test.go
@@ -1,3 +1,17 @@
+// Copyright 2025 CardinalHQ, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package traceproducer
 
 import (

--- a/scripts/install-dev-tools.sh
+++ b/scripts/install-dev-tools.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Copyright 2025 CardinalHQ, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# Dev tool versions - update these to change versions across the project
+GOLANGCI_LINT_VERSION="v1.64.8"
+LICENSE_EYE_VERSION="latest"
+
+# Project root directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BIN_DIR="$PROJECT_ROOT/bin"
+
+echo "Installing development tools to $BIN_DIR..."
+
+# Create bin directory if it doesn't exist
+mkdir -p "$BIN_DIR"
+
+# Install tools with pinned versions to project-local bin directory
+echo "Installing golangci-lint $GOLANGCI_LINT_VERSION..."
+GOBIN="$BIN_DIR" go install "github.com/golangci/golangci-lint/cmd/golangci-lint@$GOLANGCI_LINT_VERSION" || echo "Failed to install golangci-lint"
+
+echo "Installing license-eye $LICENSE_EYE_VERSION..."
+GOBIN="$BIN_DIR" go install "github.com/apache/skywalking-eyes/cmd/license-eye@$LICENSE_EYE_VERSION" || echo "Failed to install license-eye"
+
+echo ""
+echo "Installation complete. Installed tools:"
+ls -la "$BIN_DIR" | grep -E "golangci-lint|license-eye" || echo "No tools found"


### PR DESCRIPTION
## Summary
- Add `scripts/install-dev-tools.sh` to install `golangci-lint` and `license-eye` into project-local `./bin/`, matching the lakerunner pattern
- Makefile targets (`lint`, `license-check`) use lazy file prerequisites to auto-trigger the install script only when binaries are missing
- Remove `//tool` directives from `go.mod`
- Fix pre-existing missing license header on `traceproducer_test.go` and gofmt issue in `timeline.go`

## Test plan
- [x] `make clean && make check` passes (tools reinstall, tests/license/lint all green)